### PR TITLE
Add release platform links infrastructure

### DIFF
--- a/app/Enum/ReleasePlatform.php
+++ b/app/Enum/ReleasePlatform.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Gazelle\Enum;
+
+enum ReleasePlatform: string {
+    case Spotify = 'Spotify';
+    case AppleMusic = 'Apple Music';
+    case Bandcamp = 'Bandcamp';
+    case SoundCloud = 'SoundCloud';
+    case YouTube = 'YouTube';
+}

--- a/app/Json/TGroup.php
+++ b/app/Json/TGroup.php
@@ -45,6 +45,7 @@ class TGroup extends \Gazelle\Json {
             'vanityHouse'     => $tgroup->isShowcase(),
             'isBookmarked'    => (new \Gazelle\User\Bookmark($this->user))->isTorrentBookmarked($tgroup->id()),
             'tags'            => array_values($tgroup->tagNameList()),
+            'platforms'       => (new \Gazelle\Manager\ReleasePlatform())->listByRelease($tgroup->id()),
             'musicInfo'       => $musicInfo,
         ];
     }

--- a/app/Manager/ReleasePlatform.php
+++ b/app/Manager/ReleasePlatform.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Gazelle\Manager;
+
+class ReleasePlatform extends \Gazelle\BaseManager {
+    public function findById(int $id): ?\Gazelle\ReleasePlatform {
+        $found = self::$db->scalar("SELECT 1 FROM release_platform WHERE ID = ?", $id);
+        if (!$found) {
+            return null;
+        }
+        return new \Gazelle\ReleasePlatform($id);
+    }
+
+    public function create(int $releaseId, string $platform, string $url): \Gazelle\ReleasePlatform {
+        self::$db->prepared_query(
+            "INSERT INTO release_platform (ReleaseID, Platform, Url) VALUES (?, ?, ?)",
+            $releaseId, $platform, $url
+        );
+        return $this->findById(self::$db->inserted_id());
+    }
+
+    public function listByRelease(int $releaseId): array {
+        self::$db->prepared_query(
+            "SELECT ID, Platform, Url FROM release_platform WHERE ReleaseID = ? ORDER BY ID",
+            $releaseId
+        );
+        return self::$db->to_array(false, MYSQLI_ASSOC, false);
+    }
+
+    public function update(int $id, string $platform, string $url): int {
+        self::$db->prepared_query(
+            "UPDATE release_platform SET Platform = ?, Url = ?, updated = NOW() WHERE ID = ?",
+            $platform, $url, $id
+        );
+        return self::$db->affected_rows();
+    }
+
+    public function remove(int $id): int {
+        self::$db->prepared_query("DELETE FROM release_platform WHERE ID = ?", $id);
+        return self::$db->affected_rows();
+    }
+
+    public function removeForRelease(int $releaseId): int {
+        self::$db->prepared_query("DELETE FROM release_platform WHERE ReleaseID = ?", $releaseId);
+        return self::$db->affected_rows();
+    }
+}

--- a/app/ReleasePlatform.php
+++ b/app/ReleasePlatform.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Gazelle;
+
+class ReleasePlatform extends BaseObject {
+    final public const tableName = 'release_platform';
+
+    public function flush(): static {
+        $this->info = [];
+        return $this;
+    }
+
+    public function link(): string {
+        return $this->url();
+    }
+
+    public function location(): string {
+        return $this->url();
+    }
+
+    protected function info(): array {
+        if (!isset($this->info) || !$this->info) {
+            $this->info = self::$db->row(
+                "SELECT ReleaseID, Platform, Url FROM release_platform WHERE ID = ?",
+                $this->id
+            ) ?? [];
+        }
+        return $this->info;
+    }
+
+    public function releaseId(): int {
+        return (int)$this->info()['ReleaseID'];
+    }
+
+    public function platform(): string {
+        return $this->info()['Platform'];
+    }
+
+    public function url(): string {
+        return $this->info()['Url'];
+    }
+
+    public function update(string $platform, string $url): int {
+        self::$db->prepared_query(
+            "UPDATE release_platform SET Platform = ?, Url = ?, updated = NOW() WHERE ID = ?",
+            $platform, $url, $this->id
+        );
+        $this->flush();
+        return self::$db->affected_rows();
+    }
+
+    public function remove(): int {
+        self::$db->prepared_query(
+            "DELETE FROM release_platform WHERE ID = ?",
+            $this->id
+        );
+        return self::$db->affected_rows();
+    }
+}

--- a/misc/phinx/migrations/20250205000000_release_platform.php
+++ b/misc/phinx/migrations/20250205000000_release_platform.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class ReleasePlatform extends AbstractMigration {
+    public function up(): void {
+        $this->table('release_platform', ['id' => false, 'primary_key' => 'ID'])
+            ->addColumn('ID', 'integer', ['limit' => 10, 'identity' => true])
+            ->addColumn('ReleaseID', 'integer', ['limit' => 10])
+            ->addColumn('Platform', 'enum', ['values' => [
+                'Spotify',
+                'Apple Music',
+                'Bandcamp',
+                'SoundCloud',
+                'YouTube',
+            ]])
+            ->addColumn('Url', 'string', ['limit' => 255])
+            ->addColumn('created', 'datetime', ['default' => 'CURRENT_TIMESTAMP'])
+            ->addColumn('updated', 'datetime', ['default' => 'CURRENT_TIMESTAMP', 'update' => 'CURRENT_TIMESTAMP'])
+            ->addIndex(['ReleaseID'])
+            ->addForeignKey('ReleaseID', 'torrents_group', 'ID', ['delete' => 'CASCADE', 'update' => 'CASCADE'])
+            ->create();
+    }
+
+    public function down(): void {
+        $this->table('release_platform')->drop()->save();
+    }
+}

--- a/sections/ajax/index.php
+++ b/sections/ajax/index.php
@@ -32,6 +32,7 @@ $LimitedPages = [
     'tcomments'       => [5, 10],
     'top10'           => [2, 60],
     'torrentgroup'    => [15, 60],
+    'release_platform'=> [5, 10],
     'user'            => [4, 60],
     'user_recents'    => [5, 10],
     'userhistory'     => [5, 10],
@@ -119,6 +120,9 @@ switch ($Action) {
         break;
     case 'torrentgroupalbumart':        // so the album art script can function without breaking the ratelimit
         include_once 'torrentgroupalbumart.php';
+        break;
+    case 'release_platform':
+        include_once 'release_platform.php';
         break;
     case 'torrent_remove_cover_art':
         include_once 'torrent_remove_cover_art.php';

--- a/sections/ajax/release_platform.php
+++ b/sections/ajax/release_platform.php
@@ -1,0 +1,46 @@
+<?php
+/** @phpstan-var \Gazelle\User $Viewer */
+
+$mode = $_POST['mode'] ?? $_GET['mode'] ?? 'list';
+$releaseId = (int)($_POST['release_id'] ?? $_GET['release_id'] ?? 0);
+$manager = new Gazelle\Manager\ReleasePlatform();
+
+switch ($mode) {
+    case 'create':
+        authorize();
+        $platform = $_POST['platform'] ?? '';
+        $url = $_POST['url'] ?? '';
+        if (!$releaseId || !$platform || !$url) {
+            json_error('missing parameters');
+        }
+        $rp = $manager->create($releaseId, $platform, $url);
+        json_print('success', ['id' => $rp->id()]);
+        break;
+    case 'update':
+        authorize();
+        $id = (int)($_POST['id'] ?? 0);
+        $platform = $_POST['platform'] ?? '';
+        $url = $_POST['url'] ?? '';
+        if (!$id || !$platform || !$url) {
+            json_error('missing parameters');
+        }
+        $manager->update($id, $platform, $url);
+        json_print('success', ['status' => 'ok']);
+        break;
+    case 'delete':
+        authorize();
+        $id = (int)($_POST['id'] ?? 0);
+        if (!$id) {
+            json_error('missing parameters');
+        }
+        $manager->remove($id);
+        json_print('success', ['status' => 'ok']);
+        break;
+    case 'list':
+    default:
+        if (!$releaseId) {
+            json_error('missing parameters');
+        }
+        json_print('success', ['platforms' => $manager->listByRelease($releaseId)]);
+        break;
+}


### PR DESCRIPTION
## Summary
- add release platform enum and migration
- expose platform links via TGroup JSON
- provide AJAX endpoint for release platform CRUD

## Testing
- `php -l app/Enum/ReleasePlatform.php`
- `php -l app/Manager/ReleasePlatform.php`
- `php -l app/ReleasePlatform.php`
- `php -l misc/phinx/migrations/20250205000000_release_platform.php`
- `php -l sections/ajax/release_platform.php`
- `php -l app/Json/TGroup.php`
- `php -l sections/ajax/index.php`
- `composer install` *(fails: ext-gmp missing)*


------
https://chatgpt.com/codex/tasks/task_e_68aa90ce65708333a3672d9eeb1b6ad1