### PR TITLE
Rename torrent feeds to release feeds

### DIFF
--- a/app/Feed.php
+++ b/app/Feed.php
@@ -90,8 +90,8 @@ class Feed extends Base {
     public function bookmark(User $user, string $feedName): string {
         return $this->wrap(
             $this->channel(
-                'Bookmarked torrent notifications',
-                'RSS feed for bookmarked torrents'
+                'Bookmarked edition notifications',
+                'RSS feed for bookmarked editions'
             )
             . $this->retrieve($user, $feedName)
         );
@@ -101,34 +101,34 @@ class Feed extends Base {
         return $this->wrap(
             $this->channel(
                 match ($feedName) {
-                    'torrents_all'        => 'Everything',
-                    'torrents_apps'       => 'Applications',
-                    'torrents_abooks'     => 'Audiobooks',
-                    'torrents_comedy'     => 'Comedy',
-                    'torrents_comics'     => 'Comics',
-                    'torrents_ebooks'     => 'E-Books',
-                    'torrents_evids'      => 'E-Learning Videos',
-                    'torrents_flac'       => 'FLACs',
-                    'torrents_lossless'   => 'Lossless',
-                    'torrents_music'      => 'Music',
-                    'torrents_mp3'        => 'MP3s',
-                    'torrents_vinyl'      => 'Vinyl',
-                    'torrents_lossless24' => '24bit Lossless',
+                    'releases_all'        => 'Everything',
+                    'releases_apps'       => 'Applications',
+                    'releases_abooks'     => 'Audiobooks',
+                    'releases_comedy'     => 'Comedy',
+                    'releases_comics'     => 'Comics',
+                    'releases_ebooks'     => 'E-Books',
+                    'releases_evids'      => 'E-Learning Videos',
+                    'releases_flac'       => 'FLACs',
+                    'releases_lossless'   => 'Lossless',
+                    'releases_music'      => 'Music',
+                    'releases_mp3'        => 'MP3s',
+                    'releases_vinyl'      => 'Vinyl',
+                    'releases_lossless24' => '24bit Lossless',
                 },
                 match ($feedName) {
-                    'torrents_all'        => 'RSS feed for new uploads',
-                    'torrents_apps'       => 'RSS feed for new application uploads',
-                    'torrents_comedy'     => 'RSS feed for new comedy uploads',
-                    'torrents_comics'     => 'RSS feed for new comics uploads',
-                    'torrents_abooks'     => 'RSS feed for new audiobook torrent uploads',
-                    'torrents_ebooks'     => 'RSS feed for new e-books uploads',
-                    'torrents_evids'      => 'RSS feed for new e-learning videos uploads',
-                    'torrents_flac'       => 'RSS feed for new FLAC uploads',
-                    'torrents_lossless'   => 'RSS feed for new lossless uploads',
-                    'torrents_mp3'        => 'RSS feed for new MP3s uploads',
-                    'torrents_music'      => 'RSS feed for new music uploads',
-                    'torrents_vinyl'      => 'RSS feed for new vinyl-sourced uploads',
-                    'torrents_lossless24' => 'RSS feed for new 24bit lossless uploads',
+                    'releases_all'        => 'RSS feed for new release uploads',
+                    'releases_apps'       => 'RSS feed for new application releases',
+                    'releases_comedy'     => 'RSS feed for new comedy releases',
+                    'releases_comics'     => 'RSS feed for new comics releases',
+                    'releases_abooks'     => 'RSS feed for new audiobook release uploads',
+                    'releases_ebooks'     => 'RSS feed for new e-book releases',
+                    'releases_evids'      => 'RSS feed for new e-learning video releases',
+                    'releases_flac'       => 'RSS feed for new FLAC releases',
+                    'releases_lossless'   => 'RSS feed for new lossless releases',
+                    'releases_mp3'        => 'RSS feed for new MP3 releases',
+                    'releases_music'      => 'RSS feed for new music releases',
+                    'releases_vinyl'      => 'RSS feed for new vinyl-sourced releases',
+                    'releases_lossless24' => 'RSS feed for new 24bit lossless releases',
                 }
             ) . $this->retrieve($user, $feedName)
         );

--- a/app/Notification/Upload.php
+++ b/app/Notification/Upload.php
@@ -220,8 +220,8 @@ class Upload extends \Gazelle\Base {
                 ", $tgroupId, $this->torrent->id(), $notify['user_id'], $notify['filter_id']
             );
             $n += self::$db->affected_rows();
-            $this->rss[] = "torrents_notify_{$notify['passkey']}";
-            $this->rss[] = "torrents_notify_{$notify['filter_id']}_{$notify['passkey']}";
+            $this->rss[] = "releases_notify_{$notify['passkey']}";
+            $this->rss[] = "releases_notify_{$notify['filter_id']}_{$notify['passkey']}";
             self::$cache->delete_value("user_notify_upload_{$notify['user_id']}");
         }
 
@@ -237,29 +237,29 @@ class Upload extends \Gazelle\Base {
 
         // set up RSS feed categories
         $this->rss[] = match ($tgroup->categoryName()) {
-            'Music'             => 'torrents_music',
-            'Applications'      => 'torrents_apps',
-            'Audiobooks'        => 'torrents_abooks',
-            'Comedy'            => 'torrents_comedy',
-            'Comics'            => 'torrents_comics',
-            'E-Books'           => 'torrents_ebooks',
-            'E-Learning Videos' => 'torrents_evideos',
-            default             => 'torrents_unknown',
+            'Music'             => 'releases_music',
+            'Applications'      => 'releases_apps',
+            'Audiobooks'        => 'releases_abooks',
+            'Comedy'            => 'releases_comedy',
+            'Comics'            => 'releases_comics',
+            'E-Books'           => 'releases_ebooks',
+            'E-Learning Videos' => 'releases_evids',
+            default             => 'releases_unknown',
         };
 
         $torrent = $this->torrent;
         if (in_array($torrent->format(), ['FLAC', 'MP3'])) {
-            $this->rss[] = 'torrents_' . strtolower($torrent->format());
+            $this->rss[] = 'releases_' . strtolower($torrent->format());
         }
         if ($torrent->encoding() === 'Lossless') {
-            $this->rss[] = 'torrents_lossless';
+            $this->rss[] = 'releases_lossless';
         } elseif ($torrent->encoding() === '24bit Lossless') {
-            $this->rss[] = 'torrents_lossless24';
+            $this->rss[] = 'releases_lossless24';
         }
         if ($torrent->media() === 'Vinyl') {
-            $this->rss[] = 'torrents_vinyl';
+            $this->rss[] = 'releases_vinyl';
         }
-        $this->rss[] = 'torrents_all';
+        $this->rss[] = 'releases_all';
 
         $feed = new \Gazelle\Feed();
         $item = $feed->item(
@@ -280,7 +280,7 @@ class Upload extends \Gazelle\Base {
 
         // RSS for bookmarks
         self::$db->prepared_query("
-            SELECT concat('torrents_bookmarks_t_', um.torrent_pass)
+            SELECT concat('releases_bookmarks_e_', um.torrent_pass)
             FROM users_main AS um
             INNER JOIN bookmarks_torrents AS b ON (b.UserID = um.ID)
             WHERE b.GroupID = ?

--- a/app/User/Bookmark.php
+++ b/app/User/Bookmark.php
@@ -68,11 +68,11 @@ class Bookmark extends \Gazelle\BaseUser {
                     if (is_null($torrent)) {
                         continue;
                     }
-                    $Feed->populate('torrents_bookmarks_t_' . $this->user->announceKey(),
+                    $Feed->populate('releases_bookmarks_e_' . $this->user->announceKey(),
                         $Feed->item(
                             $torrent->name() . ' ' . '[' . $torrent->label($this->user) . ']',
                             \Text::strip_bbcode($tgroup->description()),
-                            "torrents.php?action=download&id={$id}&torrent_pass=[[PASSKEY]]",
+                            "editions.php?action=download&id={$id}&torrent_pass=[[PASSKEY]]",
                             date('r'),
                             $this->user->username(),
                             $torrent->group()->location(),

--- a/misc/phinx/migrations/20190824010935_user_nav.php
+++ b/misc/phinx/migrations/20190824010935_user_nav.php
@@ -46,7 +46,7 @@ class UserNav extends AbstractMigration
             [
                 'Key' => 'bookmarks',
                 'Title' => 'Bookmarks',
-                'Target' => 'bookmarks.php?type=torrents',
+                'Target' => 'bookmarks.php?type=releases',
                 'Tests' => 'bookmarks',
                 'TestUser' => false,
                 'Mandatory' => false

--- a/public/feeds.php
+++ b/public/feeds.php
@@ -41,19 +41,19 @@ if ($user->permitted('site_disable_ip_history')) {
 Gazelle\Base::setRequestContext($context);
 
 switch ($_GET['feed']) {
-    case 'torrents_abooks':
-    case 'torrents_all':
-    case 'torrents_apps':
-    case 'torrents_comedy':
-    case 'torrents_comics':
-    case 'torrents_ebooks':
-    case 'torrents_evids':
-    case 'torrents_flac':
-    case 'torrents_lossless':
-    case 'torrents_lossless24':
-    case 'torrents_mp3':
-    case 'torrents_music':
-    case 'torrents_vinyl':
+    case 'releases_abooks':
+    case 'releases_all':
+    case 'releases_apps':
+    case 'releases_comedy':
+    case 'releases_comics':
+    case 'releases_ebooks':
+    case 'releases_evids':
+    case 'releases_flac':
+    case 'releases_lossless':
+    case 'releases_lossless24':
+    case 'releases_mp3':
+    case 'releases_music':
+    case 'releases_vinyl':
         echo $feed->byFeedName($user, $_GET['feed']);
         break;
     case 'feed_news':
@@ -67,8 +67,8 @@ switch ($_GET['feed']) {
         break;
     default:
         echo match (true) {
-            str_starts_with($_GET['feed'], 'torrents_bookmarks_t_') => $feed->bookmark($user, $_GET['feed']),
-            str_starts_with($_GET['feed'], 'torrents_notify_') =>      $feed->personal($user, $_GET['feed'], $_GET['name'] ?? null),
+            str_starts_with($_GET['feed'], 'releases_bookmarks_e_') => $feed->bookmark($user, $_GET['feed']),
+            str_starts_with($_GET['feed'], 'releases_notify_')      => $feed->personal($user, $_GET['feed'], $_GET['name'] ?? null),
             default => $feed->blocked()
         };
 }

--- a/sections/bookmarks/mass_edit.php
+++ b/sections/bookmarks/mass_edit.php
@@ -3,7 +3,7 @@
 
 authorize();
 
-if ($_POST['type'] === 'torrents') {
+if ($_POST['type'] === 'releases') {
     $editor = new Gazelle\Editor\UserBookmark($Viewer->id());
     if (isset($_POST['update']) && !empty($_POST['sort'])) {
         $editor->modify($_POST['sort']);
@@ -15,4 +15,4 @@ if ($_POST['type'] === 'torrents') {
     }
 }
 
-header('Location: bookmarks.php?type=torrents');
+header('Location: bookmarks.php?type=releases');

--- a/sections/bookmarks/torrents.php
+++ b/sections/bookmarks/torrents.php
@@ -40,25 +40,25 @@ $artistLeaderboard = $bookmark->torrentArtistLeaderboard(new Gazelle\Manager\Art
 $tagLeaderboard    = $bookmark->torrentTagLeaderboard();
 $CollageCovers     = (int)($Viewer->option('CollageCovers') ?? 25);
 
-View::show_header($user->username() . " › Bookmarked torrent groups", ['js' => 'browse,collage']);
+View::show_header($user->username() . " › Bookmarked release groups", ['js' => 'browse,collage']);
 ?>
 <div class="thin">
     <div class="header">
         <h2>
 <?php
 if ($ownProfile) {
-    $feed = "torrents_bookmarks_t_" . $Viewer->announceKey();
+    $feed = "releases_bookmarks_e_" . $Viewer->announceKey();
 ?>
             <a href="feeds.php?feed=<?= $feed
             ?>&amp;passkey=<?= $Viewer->announceKey()
             ?>&amp;auth=<?= $Viewer->rssAuth($feed)
-            ?>&amp;name=<?= urlencode(SITE_NAME . ': Bookmarked Torrents')
+            ?>&amp;name=<?= urlencode(SITE_NAME . ': Bookmarked Releases')
             ?>"><img src="<?=STATIC_SERVER?>/common/symbols/rss.png" alt="RSS feed" /></a>&nbsp;
 <?php } ?>
-            <?= $user->link() ?> › Bookmarked torrent groups
+            <?= $user->link() ?> › Bookmarked release groups
         </h2>
         <div class="linkbox">
-            <a href="bookmarks.php?type=torrents" class="brackets">Torrents</a>
+            <a href="bookmarks.php?type=releases" class="brackets">Releases</a>
             <a href="bookmarks.php?type=artists" class="brackets">Artists</a>
             <a href="bookmarks.php?type=collages" class="brackets">Collages</a>
             <a href="bookmarks.php?type=requests" class="brackets">Requests</a>
@@ -66,7 +66,7 @@ if ($ownProfile) {
 if (count($bookmarkList) > 0) { ?>
             <br /><br />
             <a href="bookmarks.php?action=remove_snatched&amp;auth=<?= $Viewer->auth() ?>" class="brackets" onclick="return confirm('Are you sure you want to remove the bookmarks for all items you\'ve snatched?');">Remove snatched</a>
-            <a href="bookmarks.php?action=edit&amp;type=torrents" class="brackets">Manage torrents</a>
+            <a href="bookmarks.php?action=edit&amp;type=releases" class="brackets">Manage releases</a>
 <?php
 } ?>
         </div>
@@ -74,7 +74,7 @@ if (count($bookmarkList) > 0) { ?>
 <?php
 if (count($bookmarkList) === 0) { ?>
     <div class="box pad" align="center">
-        <h2>You have not bookmarked any torrents.</h2>
+        <h2>You have not bookmarked any releases.</h2>
     </div>
 </div>
 <?php

--- a/templates/bookmark/artist.twig
+++ b/templates/bookmark/artist.twig
@@ -3,7 +3,7 @@
     <div class="header">
         <h2>{{ user.id|user_url }} › Bookmarked artists</h2>
         <div class="linkbox">
-            <a href="bookmarks.php?type=torrents" class="brackets">Torrents</a>
+            <a href="bookmarks.php?type=releases" class="brackets">Releases</a>
             <a href="bookmarks.php?type=artists" class="brackets">Artists</a>
             <a href="bookmarks.php?type=collages" class="brackets">Collages</a>
             <a href="bookmarks.php?type=requests" class="brackets">Requests</a>

--- a/templates/bookmark/body.twig
+++ b/templates/bookmark/body.twig
@@ -1,11 +1,11 @@
-{{ header(user.username ~ ' › Organize torrent bookmarks', {'js': 'browse,vendor/jquery-ui,vendor/jquery.tablesorter,sort'}) }}
+{{ header(user.username ~ ' › Organize release bookmarks', {'js': 'browse,vendor/jquery-ui,vendor/jquery.tablesorter,sort'}) }}
 {% for b in list %}
     {% if loop.first %}
 <div class="thin">
 <div class="header">
-    <h2>{{ user.id|user_url }} › <a href="bookmarks.php?type=torrents
+    <h2>{{ user.id|user_url }} › <a href="bookmarks.php?type=releases
         {%- if user.id != viewer.id %}&amp;user_id={{ user.id }}{% endif -%}
-        ">Torrent Bookmarks</a> › Manage</h2>
+        ">Release Bookmarks</a> › Manage</h2>
 </div>
 <table width="100%" class="layout">
     <tr class="colhead"><td id="sorting_head">Sorting</td></tr>
@@ -32,7 +32,7 @@
             <th style="width: 1%;"><span><abbr class="tooltip" title="Current order">#</abbr></span></th>
             <th style="width: 1%;"><span>Year</span></th>
             <th style="width: 15%;" data-sorter="ignoreArticles"><span>Artist</span></th>
-            <th data-sorter="ignoreArticles"><span>Torrent</span></th>
+            <th data-sorter="ignoreArticles"><span>Release</span></th>
             <th style="width: 5%;" data-sorter="relativeTime"><span>Bookmarked</span></th>
             <th style="width: 1%;" id="check_all" data-sorter="false"><span>Remove</span></th>
         </tr>

--- a/templates/collage/browse.twig
+++ b/templates/collage/browse.twig
@@ -20,7 +20,7 @@
     </div>
 {% if is_bookmark %}
     <div class="linkbox">
-        <a href="bookmarks.php?type=torrents" class="brackets">Torrents</a>
+        <a href="bookmarks.php?type=releases" class="brackets">Releases</a>
         <a href="bookmarks.php?type=artists" class="brackets">Artists</a>
         <a href="bookmarks.php?type=collages" class="brackets">Collages</a>
         <a href="bookmarks.php?type=requests" class="brackets">Requests</a>

--- a/templates/index/private-header.twig
+++ b/templates/index/private-header.twig
@@ -18,23 +18,23 @@
 {{ rss_link(viewer, "feed_news", "News") }}
 {{ rss_link(viewer, "feed_blog", "Blog") }}
 {{ rss_link(viewer, "feed_changelog", "Change Log") }}
-{{ rss_link(viewer, "torrents_notify_" ~ viewer.announceKey, "Personal Torrent Notifications") }}
-{{ rss_link(viewer, "torrents_all", "All Torrents") }}
-{{ rss_link(viewer, "torrents_music", "Music Torrents") }}
-{{ rss_link(viewer, "torrents_apps", "Application Torrents") }}
-{{ rss_link(viewer, "torrents_ebooks", "E-Book Torrents") }}
-{{ rss_link(viewer, "torrents_abooks", "Audiobooks Torrents") }}
-{{ rss_link(viewer, "torrents_evids", "E-Learning Video Torrents") }}
-{{ rss_link(viewer, "torrents_comedy", "Comedy Torrents") }}
-{{ rss_link(viewer, "torrents_comics", "Comic Torrents") }}
-{{ rss_link(viewer, "torrents_mp3", "MP3 Torrents") }}
-{{ rss_link(viewer, "torrents_flac", "FLAC Torrents") }}
-{{ rss_link(viewer, "torrents_vinyl", "Vinyl Sourced Torrents") }}
-{{ rss_link(viewer, "torrents_lossless", "Lossless Torrents") }}
-{{ rss_link(viewer, "torrents_lossless24", "24bit Lossless Torrents") }}
+{{ rss_link(viewer, "releases_notify_" ~ viewer.announceKey, "Personal Release Notifications") }}
+{{ rss_link(viewer, "releases_all", "All Releases") }}
+{{ rss_link(viewer, "releases_music", "Music Releases") }}
+{{ rss_link(viewer, "releases_apps", "Application Releases") }}
+{{ rss_link(viewer, "releases_ebooks", "E-Book Releases") }}
+{{ rss_link(viewer, "releases_abooks", "Audiobook Releases") }}
+{{ rss_link(viewer, "releases_evids", "E-Learning Video Releases") }}
+{{ rss_link(viewer, "releases_comedy", "Comedy Releases") }}
+{{ rss_link(viewer, "releases_comics", "Comic Releases") }}
+{{ rss_link(viewer, "releases_mp3", "MP3 Releases") }}
+{{ rss_link(viewer, "releases_flac", "FLAC Releases") }}
+{{ rss_link(viewer, "releases_vinyl", "Vinyl Sourced Releases") }}
+{{ rss_link(viewer, "releases_lossless", "Lossless Releases") }}
+{{ rss_link(viewer, "releases_lossless24", "24bit Lossless Releases") }}
 {% if viewer.permitted('site_torrents_notify') %}
 {%     for id, name in viewer.notifyFilters %}
-{{          rss_link(viewer, "torrents_notify_" ~ id ~ "_" ~ viewer.announceKey, name) }}
+{{          rss_link(viewer, "releases_notify_" ~ id ~ "_" ~ viewer.announceKey, name) }}
 {%     endfor %}
 {% endif -%}
 {{ scss('global.css') }}

--- a/templates/request/index.twig
+++ b/templates/request/index.twig
@@ -6,7 +6,7 @@
     </div>
     <div class="linkbox">
 {% if bookmark_view %}
-        <a href="bookmarks.php?type=torrents" class="brackets">Torrents</a>
+        <a href="bookmarks.php?type=releases" class="brackets">Releases</a>
         <a href="bookmarks.php?type=artists" class="brackets">Artists</a>
         <a href="bookmarks.php?type=collages" class="brackets">Collages</a>
         <a href="bookmarks.php?type=requests" class="brackets">Requests</a>

--- a/templates/user/edit-notification-filter.twig
+++ b/templates/user/edit-notification-filter.twig
@@ -3,9 +3,9 @@
 {{ header('Manage notifications', {'js': 'vendor/jquery.validate,form_validate'}) }}
 <div class="thin">
     <div class="header">
-        <h2>Notify me of all new torrents with...</h2>
+        <h2>Notify me of all new releases with...</h2>
         <div class="linkbox">
-            <a href="torrents.php?action=notify" class="brackets">View notifications</a>
+            <a href="releases.php?action=notify" class="brackets">View notifications</a>
         </div>
     </div>
 {% for filter in list %}
@@ -15,7 +15,7 @@
     <h3>Create a new notification filter</h3>
     {% elseif list|length > 1 %}
     <h3>
-        {{ rss_a(viewer, "torrents_notify_" ~ filter.ID ~ '_' ~ viewer.announceKey, filter.Label) }}
+        {{ rss_a(viewer, "releases_notify_" ~ filter.ID ~ '_' ~ viewer.announceKey, filter.Label) }}
         <a href="user.php?action=notify_delete&amp;id={{ filter.ID }}&amp;auth={{ viewer.auth() }}" onclick="return confirm('Are you sure you want to delete this notification filter?')" class="brackets">Delete</a>
         <a href="#" onclick="$('#filter_{{ filter.ID }}').gtoggle(); return false;" class="brackets">Show</a>
     </h3>


### PR DESCRIPTION
## Summary
- rename torrent feed endpoints to release equivalents
- point feed-related code to release/edition handlers
- update bookmark and notification paths to use release names

## Testing
- `composer install --ignore-platform-req=ext-gmp` *(fails: requires GitHub token)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aad4859a9083338e111885daab6aff