### PR TITLE
feat: add release search to opensearch

### DIFF
--- a/public/opensearch.php
+++ b/public/opensearch.php
@@ -7,7 +7,7 @@ header('Content-type: application/opensearchdescription+xml');
 
 require_once __DIR__ . '/../lib/config.php';
 
-$Type = in_array(($_GET['type'] ?? ''), ['torrents','artists','requests','forums','users','wiki','log'])
+$Type = in_array(($_GET['type'] ?? ''), ['releases','artists','requests','forums','users','wiki','log'])
     ? $_GET['type']
     : 'artists';
 
@@ -23,13 +23,13 @@ switch ($Type) {
     case 'artists':
 ?>
     <Url type="text/html" method="get" template="<?=SITE_URL?>/artist.php?artistname={searchTerms}"></Url>
-    <moz:SearchForm><?=SITE_URL?>/torrents.php?action=advanced</moz:SearchForm>
+    <moz:SearchForm><?=SITE_URL?>/releases.php?action=advanced</moz:SearchForm>
 <?php
         break;
-    case 'torrents':
+    case 'releases':
 ?>
-    <Url type="text/html" method="get" template="<?=SITE_URL?>/torrents.php?action=basic&amp;searchstr={searchTerms}"></Url>
-    <moz:SearchForm><?=SITE_URL?>/torrents.php</moz:SearchForm>
+    <Url type="text/html" method="get" template="<?=SITE_URL?>/releases.php?action=basic&amp;searchstr={searchTerms}"></Url>
+    <moz:SearchForm><?=SITE_URL?>/releases.php</moz:SearchForm>
 <?php
         break;
     case 'requests':


### PR DESCRIPTION
## Summary
- add release search type to OpenSearch
- point artist search form to releases advanced search
- expose release endpoint for OpenSearch URL and form

## Testing
- `php -l public/opensearch.php`
- `make check-php` *(fails: missing separator in Makefile)*

------
https://chatgpt.com/codex/tasks/task_e_68aad97fce40833388d4e164d85886fe