### PR TITLE
refactor: replace torrent stats with release stats

### DIFF
--- a/app/Json/Stats/General.php
+++ b/app/Json/Stats/General.php
@@ -5,7 +5,7 @@ namespace Gazelle\Json\Stats;
 class General extends \Gazelle\Json {
     public function __construct(
         protected \Gazelle\Stats\Request $reqStat,
-        protected \Gazelle\Stats\Torrent $torStat,
+        protected \Gazelle\Stats\Release $torStat,
         protected \Gazelle\Stats\Users   $userStat,
     ) {}
 

--- a/app/Json/Stats/Release.php
+++ b/app/Json/Stats/Release.php
@@ -2,9 +2,9 @@
 
 namespace Gazelle\Json\Stats;
 
-class Torrent extends \Gazelle\Json {
+class Release extends \Gazelle\Json {
     public function __construct(
-        protected \Gazelle\Stats\Torrent $stat,
+        protected \Gazelle\Stats\Release $stat,
     ) {}
 
     public function payload(): array {

--- a/app/User/Activity.php
+++ b/app/User/Activity.php
@@ -187,7 +187,7 @@ class Activity extends \Gazelle\BaseUser {
         return $this;
     }
 
-    public function setStats(int $threshold, \Gazelle\Stats\Torrent $stats): static {
+    public function setStats(int $threshold, \Gazelle\Stats\Release $stats): static {
         if ($this->user->permitted('admin_site_debug')) {
             $total = array_reduce(
                 array_map(

--- a/classes/view.class.php
+++ b/classes/view.class.php
@@ -61,7 +61,7 @@ class View {
             $threshold = (new \Gazelle\Manager\SiteOption())
                 ->findValueByName('download-warning-threshold');
             if ($threshold) {
-                $activity->setStats((int)$threshold, new Gazelle\Stats\Torrent());
+                $activity->setStats((int)$threshold, new Gazelle\Stats\Release());
             }
 
             if (OPEN_EXTERNAL_REFERRALS) {

--- a/sections/ajax/stats.php
+++ b/sections/ajax/stats.php
@@ -2,7 +2,7 @@
 
 echo (new Gazelle\Json\Stats\General(
     new Gazelle\Stats\Request(),
-    new Gazelle\Stats\Torrent(),
+    new Gazelle\Stats\Release(),
     new Gazelle\Stats\Users(),
 ))
     ->setVersion(2)

--- a/sections/ajax/stats/torrents.php
+++ b/sections/ajax/stats/torrents.php
@@ -1,5 +1,5 @@
 <?php
 
-echo (new Gazelle\Json\Stats\Torrent(new Gazelle\Stats\Torrent()))
+echo (new Gazelle\Json\Stats\Release(new Gazelle\Stats\Release()))
     ->setVersion(2)
     ->response();

--- a/sections/stats/torrents.php
+++ b/sections/stats/torrents.php
@@ -1,7 +1,7 @@
 <?php
 /** @phpstan-var \Twig\Environment $Twig */
 
-$statsTor = new Gazelle\Stats\Torrent();
+$statsTor = new Gazelle\Stats\Release();
 $flow = $statsTor->flow();
 
 echo $Twig->render('stats/torrent.twig', [

--- a/sections/tools/data/torrent_stats.php
+++ b/sections/tools/data/torrent_stats.php
@@ -12,7 +12,7 @@ $userMan = new Gazelle\Manager\User();
 echo $Twig->render('admin/stats/torrent.twig', [
     'notification' => new Gazelle\Manager\Notification(),
     'reaper'       => new Gazelle\Torrent\Reaper(new Gazelle\Manager\Torrent(), $userMan),
-    'torr_stat'    => new Gazelle\Stats\Torrent(),
+    'torr_stat'    => new Gazelle\Stats\Release(),
     'user_stat'    => new Gazelle\Stats\Users(),
     'user_man'     => $userMan,
 ]);


### PR DESCRIPTION
## Summary
- replace Stats\Torrent with new Stats\Release using `release`/`edition` tables
- point stats consumers and ajax endpoints to Stats\Release

## Testing
- `bin/lint-staged` *(fails: web container isn't running)*
- `docker compose exec -T web vendor/bin/phpunit -c misc/phpunit.xml` *(fails: command not found: docker)*
- `git diff --name-only --cached | grep '\.php$' | xargs -I{} php -l {}`


------
https://chatgpt.com/codex/tasks/task_e_68aadb1d45e083338f0d8bbd7e34f78b