### PR TITLE
Remove torrent references from bootstrap and Sphinx configs

### DIFF
--- a/misc/docker/sphinxsearch/sphinx.conf
+++ b/misc/docker/sphinxsearch/sphinx.conf
@@ -7,7 +7,7 @@ source connect {
     sql_port = 3306
 }
 
-source torrents_base : connect {
+source releases_base : connect {
     sql_attr_uint = groupid
     sql_attr_uint = time
     sql_attr_uint = categoryid
@@ -24,23 +24,22 @@ source torrents_base : connect {
     sql_attr_bool = hascue
     sql_attr_uint = freetorrent
 }
-source torrents : torrents_base {
-    #By inheriting from torrents_base, we keep all the connection info
+source releases : releases_base {
+    #By inheriting from releases_base, we keep all the connection info
     sql_query_pre = SET group_concat_max_len = 101400
     sql_query_pre = SET @starttime = NOW()
-    sql_query_pre = REPLACE INTO sphinx_index_last_pos VALUES ('torrents', UNIX_TIMESTAMP(@starttime))
+    sql_query_pre = REPLACE INTO sphinx_index_last_pos VALUES ('releases', UNIX_TIMESTAMP(@starttime))
     sql_query_pre = TRUNCATE TABLE sphinx_tg
     sql_query_pre = INSERT INTO sphinx_tg \
         (id, name, year, rlabel, cnumber, catid, reltype, \
             vanityhouse, tags) \
-        SELECT tg.id, tg.name, tg.year, tg.recordlabel, tg.cataloguenumber, \
-            tg.categoryid, tg.releasetype, tg.vanityhouse, \
+        SELECT r.id, r.name, r.year, r.record_label, r.catalog_number, \
+            0, r.release_type, r.showcase, \
             replace(group_concat(t.Name SEPARATOR ' '), '.', '_') \
-        FROM torrents_group tg \
-        INNER JOIN release_tag tt ON (tt.release_id = tg.ID) \
+        FROM release r \
+        INNER JOIN release_tag tt ON (tt.release_id = r.ID) \
         INNER JOIN tags t ON (t.ID = tt.TagID) \
-        WHERE tg.time < @starttime \
-        GROUP BY tg.ID
+        GROUP BY r.ID
     sql_query_pre = TRUNCATE TABLE sphinx_t
     sql_query_pre = INSERT INTO sphinx_t \
         (id, gid, size, snatched, seeders, leechers, time, logscore, scene, \
@@ -77,18 +76,18 @@ source torrents : torrents_base {
         INNER JOIN sphinx_tg AS g ON (t.gid = g.id)
     sql_joined_field = artistname from query; \
         SELECT t.id, aname FROM sphinx_a JOIN sphinx_t AS t USING(gid) ORDER BY t.id ASC;
-    sql_query_post_index = DELETE FROM sphinx_delta WHERE created <= \
-        (SELECT FROM_UNIXTIME(ID) FROM sphinx_index_last_pos WHERE type = 'torrents')
+    sql_query_post_index = DELETE FROM sphinx_releases_delta WHERE created <= \
+        (SELECT FROM_UNIXTIME(ID) FROM sphinx_index_last_pos WHERE type = 'releases')
 }
-index torrents {
-    source = torrents
-    path = /var/lib/sphinxsearch/data/torrents
+index releases {
+    source = releases
+    path = /var/lib/sphinxsearch/data/releases
     dict = keywords
 #    stopwords = /etc/sphinx/stopwords.txt # Path to file containing a space separated list of words not to index
     preopen = 1
     morphology = none
     min_word_len = 2
-    phrase_boundary = U+F7 # This needs to the the same as the file delimiter in classes/torrents.class.php
+    phrase_boundary = U+F7 # This needs to the the same as the file delimiter in classes/release.class.php
     phrase_boundary_step = 50
     infix_fields = taglist
     min_infix_len = 3
@@ -285,13 +284,13 @@ index torrents {
     blend_chars = !, ", U+23, $, %, &, ', (, ), *, +, U+2C, -, ., /, :, U+3B, <, =, >, ?, @, U+5B, U+5C, U+5D, ^, U+60, U+7C, U+7E, U+A1..U+BF
     blend_mode = trim_none, trim_head, trim_tail, trim_both
 }
-source delta : torrents_base {
-    sql_query = SELECT *, Year AS yearfulltext FROM sphinx_delta WHERE Size > 0;
-    sql_query_killlist = SELECT ID FROM sphinx_delta
+source releases_delta : releases_base {
+    sql_query = SELECT *, Year AS yearfulltext FROM sphinx_releases_delta WHERE Size > 0;
+    sql_query_killlist = SELECT ID FROM sphinx_releases_delta
 }
-index delta : torrents {
-    source = delta
-    path = /var/lib/sphinxsearch/data/delta
+index releases_delta : releases {
+    source = releases_delta
+    path = /var/lib/sphinxsearch/data/releases_delta
 }
 
 source requests_base : connect {
@@ -376,7 +375,7 @@ source requests_delta : requests_base {
         SELECT b.RequestID, b.UserID FROM bookmarks_requests AS b \
         JOIN sphinx_requests_delta AS d ON d.ID = b.RequestID
 }
-index requests : torrents {
+index requests : releases {
     source = requests
     path = /var/lib/sphinxsearch/data/requests
     infix_fields = taglist

--- a/misc/docker/web/bootstrap-base.sh
+++ b/misc/docker/web/bootstrap-base.sh
@@ -97,10 +97,9 @@ if [ "${DUMP_MYSQL_SCHEMA}" = 1 ]; then
     mysqldump -u root -p"$MYSQL_ROOT_PASSWORD" -f --single-transaction --no-data --databases "$MYSQL_DATABASE"
 fi
 
-if [ ! -d /var/lib/gazelle/torrent ]; then
+if [ ! -d /var/lib/gazelle/riplog ]; then
     echo "Generate file storage directories..."
     time (
-        perl "${CI_PROJECT_DIR}/bin/generate-storage-dirs" /var/lib/gazelle/torrent 2 100
         perl "${CI_PROJECT_DIR}/bin/generate-storage-dirs" /var/lib/gazelle/riplog 2 100
         perl "${CI_PROJECT_DIR}/bin/generate-storage-dirs" /var/lib/gazelle/riploghtml 2 100
     )


### PR DESCRIPTION
## Summary
- Drop legacy torrent directory creation in bootstrap script
- Replace torrent Sphinx sources/indexes with release-based equivalents and adjust requests index

## Testing
- `npm test` *(fails: Missing script: "test")*
- `vendor/bin/phpunit -c misc/phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aadd85e8b083339d06c15041ff81be