### PR TITLE
docs: reference db diagrams for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,4 +9,5 @@ Follow these guidelines when modifying code in this repository:
 4. **Preserve necessary code**: Leave code unchanged when it is necessary for the site to function or can be used directly (e.g., search logic, music release metadata, artwork handling).
 5. **Questionable reuse**: If the reusability of a domain, field or entry is uncertain, leave the code unchanged and describe it in the final output with exact paths and line numbers along with how it might be reused.
 6. **Code quality and tests**: Write clean, maintainable code covered by tests. When reasonable, follow existing design and architectural patterns. Run `make lint-staged` and `make test` after making changes.
+7. **Database diagrams**: Use `docs/plantuml/current.puml` (current schema) and `docs/plantuml/target.puml` (target schema) as references. Do not modify `docs/plantuml/current.puml` under any circumstances. Only edit `docs/plantuml/target.puml` when explicitly directed in the prompt.
 


### PR DESCRIPTION
## Summary
- guide agents to consult current and target database diagrams
- forbid editing of `docs/plantuml/current.puml`
- allow `docs/plantuml/target.puml` updates only when prompted

## Testing
- `make lint-staged` *(fails: Makefile:19: missing separator)*
- `make test` *(fails: Makefile:19: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_68aad3c65628833388a74c598b833591