### PR TITLE
docs: clarify target schema status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,5 +9,7 @@ Follow these guidelines when modifying code in this repository:
 4. **Preserve necessary code**: Leave code unchanged when it is necessary for the site to function or can be used directly (e.g., search logic, music release metadata, artwork handling).
 5. **Questionable reuse**: If the reusability of a domain, field or entry is uncertain, leave the code unchanged and describe it in the final output with exact paths and line numbers along with how it might be reused.
 6. **Code quality and tests**: Write clean, maintainable code covered by tests. When reasonable, follow existing design and architectural patterns. Run `make lint-staged` and `make test` after making changes.
-7. **Database diagrams**: Use `docs/plantuml/current.puml` (current schema) and `docs/plantuml/target.puml` (target schema) as references. Do not modify `docs/plantuml/current.puml` under any circumstances. Only edit `docs/plantuml/target.puml` when explicitly directed in the prompt.
+7. **Database diagrams**: Use `docs/plantuml/current.puml` (current schema) and `docs/plantuml/target.puml` (target schema) as references.
+The target schema is not finalized and will be extended. Do not modify `docs/plantuml/current.puml` under any circumstances.
+Only edit `docs/plantuml/target.puml` when explicitly directed in the prompt.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This project customizes a Gazelle fork to produce a web1.0-style static music library.
 Follow these guidelines when modifying code in this repository:
 
-1. **Web1.0 static library**: The site must not allow user accounts or user-generated content. Only administrators may update a static music library with links to external streaming platforms.
+1. **Web1.0 static library**: The site must allow minimal user interactions with content—comments, donations and a forum. Only administrators may update a static music library with links to external streaming platforms.
 2. **Remove unrelated features**: Remove logic, functionality and data structures not directly related to representing the music library (e.g., BitTorrent tracking, user accounts, forums) when possible.
 3. **Reuse existing structures**: Where possible reuse existing data structures and logic. For example, a release page that once linked to torrent files should become a similar page that links to different music streaming platforms.
 4. **Preserve necessary code**: Leave code unchanged when it is necessary for the site to function or can be used directly (e.g., search logic, music release metadata, artwork handling).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,10 @@ This project customizes a Gazelle fork to produce a web1.0-style static music li
 Follow these guidelines when modifying code in this repository:
 
 1. **Web1.0 static library**: The site must allow minimal user interactions with content—comments, donations and a forum. Only administrators may update a static music library with links to external streaming platforms.
-2. **Remove unrelated features**: Remove logic, functionality and data structures not directly related to representing the music library (e.g., BitTorrent tracking, user accounts, forums) when possible.
+2. **Remove unrelated features**: Remove logic, functionality and data structures not directly related to representing the music library (e.g., BitTorrent tracking, ratio, bonuses etc.) when possible.
 3. **Reuse existing structures**: Where possible reuse existing data structures and logic. For example, a release page that once linked to torrent files should become a similar page that links to different music streaming platforms.
-4. **Preserve necessary code**: Leave code unchanged when it is necessary for the site to function or can be used directly (e.g., search logic, music release metadata, artwork handling).
-5. **Questionable reuse**: If the reusability of a domain, field or entry is uncertain, leave the code unchanged and describe it in the final output with exact paths and line numbers along with how it might be reused.
+4. **Preserve necessary code**: Leave code unchanged when it is necessary for the site to function or can be used directly (e.g., search logic, music release metadata, forums, comments, donations, artwork handling etc.).
+5. **Questionable reuse**: If the re-usability of a domain, field or entry is uncertain, leave the code unchanged and describe it in the final output with exact paths and line numbers along with how it might be reused.
 6. **Code quality and tests**: Write clean, maintainable code covered by tests. When reasonable, follow existing design and architectural patterns. Run `make lint-staged` and `make test` after making changes.
 7. **Database diagrams**: Use `docs/plantuml/current.puml` (current schema) and `docs/plantuml/target.puml` (target schema) as references.
 The target schema is not finalized and will be extended. Do not modify `docs/plantuml/current.puml` under any circumstances.


### PR DESCRIPTION
## Summary
- mention that the target schema will continue to evolve in database diagram guidelines

## Testing
- `make lint-staged` *(fails: Makefile:19: missing separator)*
- `make test` *(fails: Makefile:19: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0424636c8333b0378e06c8cc1840