### PR TITLE
feat: add release metrics to artist stats

### DIFF
--- a/sections/artist/artist.php
+++ b/sections/artist/artist.php
@@ -50,18 +50,12 @@ foreach ($sections as $sectionId => $groupList) {
     }
     $artistReleaseType[$sectionId]++;
 }
+echo $Twig->render('artist/stats.twig', [
+    'release_total'  => $stats->releaseTotal(),
+    'platform_total' => $stats->platformTotal(),
+]);
+
 ?>
-        <div class="box box_info box_statistics_artist">
-            <div class="head"><strong>Statistics</strong></div>
-            <ul class="stats nobullet">
-                <li>Number of groups: <?= number_format($stats->tgroupTotal()) ?></li>
-                <li>Number of torrents: <?= number_format($stats->torrentTotal()) ?></li>
-                <li>Number of snatches: <?= number_format($stats->snatchTotal()) ?></li>
-                <li>Number of seeders: <?= number_format($stats->seederTotal()) ?></li>
-                <li>Number of leechers: <?= number_format($stats->leecherTotal()) ?></li>
-            </ul>
-        </div>
-<?php
 if ($Viewer->permitted('site_collages_manage') || $Viewer->activePersonalCollages()) {
     echo $Twig->render('artist/collage-add.twig', [
         'collage_list' => $collageMan->addToArtistCollageDefault($artist, $Viewer),

--- a/templates/artist/stats.twig
+++ b/templates/artist/stats.twig
@@ -1,0 +1,8 @@
+<div class="box box_info box_statistics_artist">
+    <div class="head"><strong>Statistics</strong></div>
+    <ul class="stats nobullet">
+        <li>Number of releases: {{ release_total|number_format }}</li>
+        <li>Available platforms: {{ platform_total|number_format }}</li>
+    </ul>
+</div>
+


### PR DESCRIPTION
## Summary
- replace torrent statistics with release and platform counts for artists
- query release and platform data in artist stats
- render artist statistics via Twig template

## Testing
- `make lint-staged` *(fails: Makefile:19: missing separator)*
- `make test` *(fails: Makefile:19: missing separator)*


------
https://chatgpt.com/codex/tasks/task_e_68ac15b87e148333aac4a4ea6f206657