### PR TITLE
Align release artist tables with release schema

### DIFF
--- a/misc/phinx/migrations/20250315000000_release_artist_tag.php
+++ b/misc/phinx/migrations/20250315000000_release_artist_tag.php
@@ -27,9 +27,12 @@ class ReleaseArtistTag extends AbstractMigration {
             if ($this->fetchRow("SHOW INDEX FROM release_artist WHERE Key_name = 'GroupID'")) {
                 $this->execute("ALTER TABLE release_artist DROP INDEX GroupID");
             }
+            if ($this->table('release_artist')->hasColumn('ArtistID')) {
+                $this->execute("ALTER TABLE release_artist DROP COLUMN ArtistID");
+            }
             $this->execute("ALTER TABLE release_artist CHANGE GroupID release_id int(10) NOT NULL");
             $this->execute("ALTER TABLE release_artist ADD INDEX release_id (release_id)");
-            $this->execute("ALTER TABLE release_artist ADD PRIMARY KEY (release_id, ArtistID, Importance)");
+            $this->execute("ALTER TABLE release_artist ADD PRIMARY KEY (release_id, Importance, AliasID)");
             if ($canFk) {
                 $this->execute("ALTER TABLE release_artist ADD FOREIGN KEY (release_id) REFERENCES torrents_group(ID)");
             }
@@ -111,7 +114,7 @@ class ReleaseArtistTag extends AbstractMigration {
         }
         $this->execute("ALTER TABLE release_artist CHANGE release_id GroupID int(10) NOT NULL");
         $this->execute("ALTER TABLE release_artist ADD INDEX GroupID (GroupID)");
-        $this->execute("ALTER TABLE release_artist ADD PRIMARY KEY (GroupID, ArtistID, Importance)");
+        $this->execute("ALTER TABLE release_artist ADD PRIMARY KEY (GroupID, Importance, AliasID)");
         $this->execute("RENAME TABLE release_artist TO torrents_artists");
         if ($canFk) {
             $this->execute("ALTER TABLE torrents_artists ADD FOREIGN KEY (GroupID) REFERENCES torrents_group(ID)");

--- a/misc/phinx/migrations/20250315000000_release_artist_tag.php
+++ b/misc/phinx/migrations/20250315000000_release_artist_tag.php
@@ -23,6 +23,8 @@ class ReleaseArtistTag extends AbstractMigration {
         // torrents_artists -> release_artist (guard against previous partial runs)
         if ($this->hasTable('torrents_artists')) {
             $this->execute("RENAME TABLE torrents_artists TO release_artist");
+        }
+        if ($this->hasTable('release_artist') && $this->table('release_artist')->hasColumn('GroupID')) {
             $this->execute("ALTER TABLE release_artist DROP PRIMARY KEY");
             if ($this->fetchRow("SHOW INDEX FROM release_artist WHERE Key_name = 'GroupID'")) {
                 $this->execute("ALTER TABLE release_artist DROP INDEX GroupID");

--- a/misc/phinx/seeds/DemoArtist.php
+++ b/misc/phinx/seeds/DemoArtist.php
@@ -41,7 +41,6 @@ class DemoArtist extends AbstractSeed {
         // create a single release for the artist
         $this->table('release')->insert([
             'ID'            => 1,
-            'ArtistID'      => 0,
             'Name'          => 'Demo Release',
             'Year'          => 2024,
             'catalog_number'=> '',
@@ -53,13 +52,14 @@ class DemoArtist extends AbstractSeed {
             'showcase'      => 0,
         ])->save();
 
-        // map artist to the release (legacy schema uses GroupID)
+        // map artist to the release
         $this->table('release_artist')->insert([
-            'GroupID'    => 1,
-            'ArtistID'   => 1,
-            'AliasID'    => 1,
-            'UserID'     => 1,
-            'Importance' => 1,
+            'release_id'     => 1,
+            'AliasID'        => 1,
+            'UserID'         => 1,
+            'Importance'     => 1,
+            'artist_role_id' => 1,
+            'created'        => $now,
         ])->save();
 
         // provide a platform link for the release

--- a/misc/phinx/seeds/DemoArtist.php
+++ b/misc/phinx/seeds/DemoArtist.php
@@ -53,8 +53,9 @@ class DemoArtist extends AbstractSeed {
         ])->save();
 
         // map artist to the release
+        $idCol = $this->fetchRow("SHOW COLUMNS FROM release_artist LIKE 'release_id'") ? 'release_id' : 'GroupID';
         $this->table('release_artist')->insert([
-            'release_id'     => 1,
+            $idCol          => 1,
             'AliasID'        => 1,
             'UserID'         => 1,
             'Importance'     => 1,

--- a/sections/releases/index.php
+++ b/sections/releases/index.php
@@ -12,7 +12,7 @@ if ($search !== '') {
                 r.Year,
                 group_concat(DISTINCT aa.Name ORDER BY aa.Name SEPARATOR ', ') AS ArtistName
            FROM `release` r
-           LEFT JOIN release_artist ra ON (ra.GroupID = r.ID)
+           LEFT JOIN release_artist ra ON (ra.release_id = r.ID)
            LEFT JOIN artists_alias aa ON (aa.AliasID = ra.AliasID)
           WHERE r.Name LIKE concat('%', ?, '%')
           GROUP BY r.ID, r.Name, r.Year

--- a/sections/releases/index.php
+++ b/sections/releases/index.php
@@ -6,13 +6,14 @@ $search = trim($_GET['searchstr'] ?? '');
 $results = [];
 if ($search !== '') {
     $db = DB::DB();
+    $idCol = $db->entityExists('release_artist', 'release_id') ? 'release_id' : 'GroupID';
     $db->prepared_query(
         "SELECT r.ID,
                 r.Name,
                 r.Year,
                 group_concat(DISTINCT aa.Name ORDER BY aa.Name SEPARATOR ', ') AS ArtistName
            FROM `release` r
-           LEFT JOIN release_artist ra ON (ra.release_id = r.ID)
+           LEFT JOIN release_artist ra ON (ra.{$idCol} = r.ID)
            LEFT JOIN artists_alias aa ON (aa.AliasID = ra.AliasID)
           WHERE r.Name LIKE concat('%', ?, '%')
           GROUP BY r.ID, r.Name, r.Year


### PR DESCRIPTION
## Summary
- keep release artists keyed by `release_id` and drop legacy `ArtistID`
- map demo seed to new release schema
- query release search using `release_id`

## Testing
- `make lint-staged` *(fails: missing separator in Makefile)*
- `make test` *(fails: missing separator in Makefile)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac46f3c8388333a95c0977218ec3ee