### PR TITLE
Revise AGENTS instructions to reflect social feature support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,5 +9,5 @@ Follow these guidelines when modifying code in this repository:
 4. **Preserve necessary code**: Leave code unchanged when it is necessary for the site to function or can be used directly (e.g., search logic, music release metadata, artwork handling).
 5. **Questionable reuse**: If the reusability of a domain, field or entry is uncertain, leave the code unchanged and describe it in the final output with exact paths and line numbers along with how it might be reused.
 6. **Code quality and tests**: Write clean, maintainable code covered by tests. When reasonable, follow existing design and architectural patterns. Keep the code coverage percentage unchanged when possible by adding or adjusting tests for newly created or modified code. Run `make lint-staged` and `make test` after making changes.
-7. **Refactoring workflow**: Refactor features in the following order: view templates → controllers → domain logic → database schema.
+7. **Refactoring workflow**: Refactor features in the following order: view templates → controllers → domain logic → database schema. In this repository, `templates/` renders views, `sections/` contains controllers, and `app/` holds domain logic.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,10 @@ This project customizes a Gazelle fork to produce a web1.0-style static music li
 Follow these guidelines when modifying code in this repository:
 
 1. **Core focus**: The site remains a web1.0-style static music library, but forums, comments, private messaging, and donations are supported features.
-2. **Remove unrelated features**: Remove logic, functionality and data structures not directly related to the library or these supported social features. Legacy social features such as requests and collages remain deprecated.
+2. **Remove unrelated features**: Remove logic, functionality and data structures not directly related to the library or these supported social features. BitTorrent tracking as well as legacy social features such as requests and collages remain deprecated.
 3. **Reuse existing structures**: Where possible reuse existing data structures and logic. For example, a release page that once linked to torrent files should become a similar page that links to different music streaming platforms.
 4. **Preserve necessary code**: Leave code unchanged when it is necessary for the site to function or can be used directly (e.g., search logic, music release metadata, artwork handling).
-5. **Questionable reuse**: If the reusability of a domain, field or entry is uncertain, leave the code unchanged and describe it in the final output with exact paths and line numbers along with how it might be reused.
+5. **Questionable reuse**: If the re-usability of a domain, field or entry is uncertain, leave the code unchanged and describe it in the final output with exact paths and line numbers along with how it might be reused.
 6. **Code quality and tests**: Write clean, maintainable code covered by tests. When reasonable, follow existing design and architectural patterns. Keep the code coverage percentage unchanged when possible by adding or adjusting tests for newly created or modified code. Run `make lint-staged` and `make test` after making changes.
 7. **Refactoring workflow**: Refactor features in the following order: view templates → controllers → domain logic → database schema. In this repository, `templates/` renders views, `sections/` contains controllers, and `app/` holds domain logic.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,6 @@ Follow these guidelines when modifying code in this repository:
 3. **Reuse existing structures**: Where possible reuse existing data structures and logic. For example, a release page that once linked to torrent files should become a similar page that links to different music streaming platforms.
 4. **Preserve necessary code**: Leave code unchanged when it is necessary for the site to function or can be used directly (e.g., search logic, music release metadata, artwork handling).
 5. **Questionable reuse**: If the reusability of a domain, field or entry is uncertain, leave the code unchanged and describe it in the final output with exact paths and line numbers along with how it might be reused.
-6. **Code quality and tests**: Write clean, maintainable code covered by tests. When reasonable, follow existing design and architectural patterns. Run `make lint-staged` and `make test` after making changes.
+6. **Code quality and tests**: Write clean, maintainable code covered by tests. When reasonable, follow existing design and architectural patterns. Keep the code coverage percentage unchanged when possible by adding or adjusting tests for newly created or modified code. Run `make lint-staged` and `make test` after making changes.
 7. **Refactoring workflow**: Refactor features in the following order: view templates → controllers → domain logic → database schema.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,10 +3,11 @@
 This project customizes a Gazelle fork to produce a web1.0-style static music library.
 Follow these guidelines when modifying code in this repository:
 
-1. **Web1.0 static library**: The site must not allow user accounts or user-generated content. Only administrators may update a static music library with links to external streaming platforms.
-2. **Remove unrelated features**: Remove logic, functionality and data structures not directly related to representing the music library (e.g., BitTorrent tracking, user accounts, forums) when possible.
+1. **Core focus**: The site remains a web1.0-style static music library, but forums, comments, private messaging, and donations are supported features.
+2. **Remove unrelated features**: Remove logic, functionality and data structures not directly related to the library or these supported social features. Legacy social features such as requests and collages remain deprecated.
 3. **Reuse existing structures**: Where possible reuse existing data structures and logic. For example, a release page that once linked to torrent files should become a similar page that links to different music streaming platforms.
 4. **Preserve necessary code**: Leave code unchanged when it is necessary for the site to function or can be used directly (e.g., search logic, music release metadata, artwork handling).
 5. **Questionable reuse**: If the reusability of a domain, field or entry is uncertain, leave the code unchanged and describe it in the final output with exact paths and line numbers along with how it might be reused.
 6. **Code quality and tests**: Write clean, maintainable code covered by tests. When reasonable, follow existing design and architectural patterns. Run `make lint-staged` and `make test` after making changes.
+7. **Refactoring workflow**: Refactor features in the following order: view templates → controllers → domain logic → database schema.
 


### PR DESCRIPTION
## Summary
- Update root AGENTS guidance to clarify that forums, comments, private messaging, and donations are supported features
- Outline refactoring workflow: view templates → controllers → domain logic → database schema
- Note that other legacy social features like requests and collages remain deprecated

## Testing
- `make lint-staged`
- `make test` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7603510083339b5d1e5d078a3635