### PR TITLE
Add release group JSON and endpoint

### DIFF
--- a/sections/ajax/index.php
+++ b/sections/ajax/index.php
@@ -28,6 +28,7 @@ $LimitedPages = [
     'subscriptions'   => [5, 10],
     'tcomments'       => [5, 10],
     'torrentgroup'    => [15, 60],
+    'releasegroup'    => [15, 60],
     'user'            => [4, 60],
     'user_recents'    => [5, 10],
     'userhistory'     => [5, 10],
@@ -109,6 +110,9 @@ switch ($Action) {
         break;
     case 'torrentgroup':
         include_once 'torrentgroup.php';
+        break;
+    case 'releasegroup':
+        include_once 'releasegroup.php';
         break;
     case 'torrentgroupalbumart':        // so the album art script can function without breaking the ratelimit
         include_once 'torrentgroupalbumart.php';

--- a/sections/ajax/releasegroup.php
+++ b/sections/ajax/releasegroup.php
@@ -1,0 +1,24 @@
+<?php
+/** @phpstan-var \Gazelle\User $Viewer */
+
+$groupId  = (int)($_GET['id'] ?? 0);
+$infohash = $_GET['hash'] ?? null;
+if ($groupId && $infohash) {
+    json_error('bad parameters');
+}
+
+$tgMan = new Gazelle\Manager\TGroup();
+$tgroup = $infohash
+    ? $tgMan->findByTorrentInfohash($infohash)
+    : $tgMan->findById($groupId);
+
+if (is_null($tgroup)) {
+    json_error('bad parameters');
+}
+
+echo (new Gazelle\Json\RGroup(
+        $tgroup,
+        $Viewer,
+        new \Gazelle\Manager\ReleaseLink()
+    ))->setVersion(2)
+    ->response();


### PR DESCRIPTION
## Summary
- add `Json\RGroup` for release group data including linked streams
- create `ajax/releasegroup.php` endpoint using `Json\RGroup`
- wire up release group endpoint in AJAX index

## Testing
- `php -l app/Json/RGroup.php`
- `php -l sections/ajax/releasegroup.php`
- `php -l sections/ajax/index.php`
- `vendor/bin/phpunit -c misc/phpunit.xml` *(fails: No such file or directory)*
- `make test` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8795153083338d4b23a06fafedd9