### PR TITLE
Add ReleaseLink domain and JSON for streaming links

### DIFF
--- a/app/Json/ReleaseLink.php
+++ b/app/Json/ReleaseLink.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Gazelle\Json;
+
+class ReleaseLink extends \Gazelle\Json {
+    public function __construct(
+        protected \Gazelle\ReleaseLink $link,
+        protected \Gazelle\User        $user,
+        protected \Gazelle\Manager\ReleaseLink $linkMan,
+    ) {}
+
+    public function linkPayload(): array {
+        return [
+            'id'       => $this->link->id(),
+            'platform' => $this->link->platform(),
+            'url'      => $this->link->url(),
+            'format'   => $this->link->format(),
+            'bitrate'  => $this->link->bitrate(),
+        ];
+    }
+
+    public function payload(): array {
+        return [
+            'group' => (new TGroup($this->link->tgroup(), $this->user, new \Gazelle\Manager\Torrent()))->tgroupPayload(),
+            'link'  => $this->linkPayload(),
+        ];
+    }
+}

--- a/app/Manager/ReleaseLink.php
+++ b/app/Manager/ReleaseLink.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Gazelle\Manager;
+
+class ReleaseLink extends \Gazelle\BaseManager {
+    protected const ID_KEY    = 'rel_link_%d';
+    protected const GROUP_KEY = 'rel_link_gid_%d';
+
+    public function findById(int $id): ?\Gazelle\ReleaseLink {
+        $key = sprintf(self::ID_KEY, $id);
+        $id  = self::$cache->get_value($key);
+        if ($id === false) {
+            $id = self::$db->scalar(
+                "SELECT ID FROM release_platform WHERE ID = ?",
+                $id
+            );
+            if ($id) {
+                self::$cache->cache_value($key, $id, 86400);
+            }
+        }
+        return $id ? new \Gazelle\ReleaseLink($id) : null;
+    }
+
+    public function linkIdList(int $tgroupId): array {
+        $key  = sprintf(self::GROUP_KEY, $tgroupId);
+        $list = self::$cache->get_value($key);
+        if ($list === false) {
+            self::$db->prepared_query(
+                "SELECT ID
+                FROM release_platform
+                WHERE ReleaseID = ?
+                ORDER BY ID",
+                $tgroupId
+            );
+            $list = self::$db->collect(0, false);
+            self::$cache->cache_value($key, $list, 86400);
+        }
+        return $list;
+    }
+}

--- a/app/ReleaseLink.php
+++ b/app/ReleaseLink.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Gazelle;
+
+class ReleaseLink extends BaseObject {
+    final public const tableName = 'release_platform';
+
+    protected ?TGroup $tgroup = null;
+
+    public function flush(): static {
+        unset($this->info);
+        unset($this->tgroup);
+        return $this;
+    }
+
+    public function link(): string {
+        return sprintf('<a href="%s">%s</a>', $this->url(), display_str($this->platform()));
+    }
+
+    public function location(): string {
+        return $this->url();
+    }
+
+    protected function infoRow(): array {
+        return $this->info ??= self::$db->rowAssoc(
+            "SELECT ReleaseID AS release_id,
+                Platform AS platform,
+                Url      AS url,
+                Format   AS format,
+                Bitrate  AS bitrate
+            FROM release_platform
+            WHERE ID = ?",
+            $this->id
+        );
+    }
+
+    public function tgroupId(): int {
+        return (int)$this->infoRow()['release_id'];
+    }
+
+    public function tgroup(): TGroup {
+        return $this->tgroup ??= new TGroup($this->tgroupId());
+    }
+
+    public function platform(): string {
+        return $this->infoRow()['platform'];
+    }
+
+    public function url(): string {
+        return $this->infoRow()['url'];
+    }
+
+    public function format(): ?string {
+        return $this->infoRow()['format'];
+    }
+
+    public function bitrate(): ?string {
+        return $this->infoRow()['bitrate'];
+    }
+
+    public function info(): array {
+        $row = $this->infoRow();
+        return [
+            'id'       => $this->id,
+            'platform' => $row['platform'],
+            'url'      => $row['url'],
+            'format'   => $row['format'],
+            'bitrate'  => $row['bitrate'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Add ReleaseLink domain and manager to fetch streaming links for release groups
- Provide JSON serializer for ReleaseLink exposing platform, URL, format and bitrate

## Testing
- `php -l app/Json/ReleaseLink.php`
- `php -l app/ReleaseLink.php`
- `php -l app/Manager/ReleaseLink.php`
- `vendor/bin/phpunit` *(fails: vendor/bin/phpunit: No such file or directory)*
- `composer install` *(fails: requires ext-gmp which is missing)*
- `apt-get update` *(fails: repository InRelease 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae00b9d4108333ab7b1d033b112056