### PR TITLE
Use release group ID for streaming link payloads

### DIFF
--- a/app/Manager/RGroup.php
+++ b/app/Manager/RGroup.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Gazelle\Manager;
+
+class RGroup extends TGroup
+{
+}
+

--- a/sections/ajax/torrentgroup.php
+++ b/sections/ajax/torrentgroup.php
@@ -1,24 +1,20 @@
 <?php
 /** @phpstan-var \Gazelle\User $Viewer */
 
-$groupId  = (int)($_GET['id'] ?? 0);
-$infohash = $_GET['hash'] ?? null;
-if ($groupId && $infohash) {
+$groupId = (int)($_GET['id'] ?? 0);
+if (!$groupId) {
     json_error('bad parameters');
 }
 
-$tgMan = new Gazelle\Manager\TGroup();
-$tgroup = $infohash
-    ? $tgMan->findByTorrentInfohash($infohash)
-    : $tgMan->findById($groupId);
-
+$rgMan  = new Gazelle\Manager\RGroup();
+$tgroup = $rgMan->findById($groupId);
 if (is_null($tgroup)) {
     json_error('bad parameters');
 }
 
-echo (new Gazelle\Json\TGroup(
+echo (new Gazelle\Json\RGroup(
         $tgroup,
         $Viewer,
-        (new \Gazelle\Manager\Torrent())->setViewer($Viewer))
-    )->setVersion(2)
+        new \Gazelle\Manager\ReleaseLink()
+    ))->setVersion(2)
     ->response();


### PR DESCRIPTION
## Summary
- Restrict `torrentgroup` AJAX endpoint to internal release group IDs
- Replace torrent lookups with `Manager\RGroup` and `Json\RGroup`
- Provide streaming link payloads via `Manager\ReleaseLink`

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: requires ext-gmp and GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68ae04e33a108333b10ad11c70c36b20