### PR TITLE
Switch artist page to release links

### DIFF
--- a/sections/artist/artist.php
+++ b/sections/artist/artist.php
@@ -17,7 +17,7 @@ $artistId = $artist->id();
 
 $bookmark   = new Gazelle\User\Bookmark($Viewer);
 $tgMan      = (new Gazelle\Manager\TGroup())->setViewer($Viewer);
-$torMan     = (new Gazelle\Manager\Torrent())->setViewer($Viewer);
+$linkMan    = new Gazelle\Manager\ReleaseLink();
 $stats      = new Gazelle\Stats\Artist($artistId);
 $userMan    = new Gazelle\Manager\User();
 $vote       = new Gazelle\User\Vote($Viewer);
@@ -185,7 +185,6 @@ if ($sections = $artist->sections()) {
 <?php
     $urlStem = (new Gazelle\User\Stylesheet($Viewer))->imagePath();
     $groupsClosed = (bool)$Viewer->option('TorrentGrouping');
-    $snatcher = $Viewer->snatch();
 
     foreach ($sections as $sectionId => $groupList) {
         $sectionClosed = (bool)($sortHide[$sectionId] ?? 0);
@@ -242,16 +241,13 @@ if ($sections = $artist->sections()) {
                 </td>
             </tr>
 <?php
-        echo $Twig->render('torrent/detail-torrentgroup.twig', [
-            'colspan_add'     => 1,
-            'hide'            => $groupsClosed || $sectionClosed,
-            'is_snatched_grp' => $isSnatched,
-            'snatcher'        => $snatcher,
-            'section_id'      => $sectionId,
-            'tgroup'          => $tgroup,
-            'torrent_list'    => object_generator($torMan, $tgroup->torrentIdList()),
-            'tor_man'         => $torMan,
-            'viewer'          => $Viewer,
+        echo $Twig->render('release/detail-releasegroup.twig', [
+            'colspan_add'  => 1,
+            'hide'         => $groupsClosed || $sectionClosed,
+            'section_id'   => $sectionId,
+            'tgroup'       => $tgroup,
+            'link_list'    => object_generator($linkMan, $linkMan->linkIdList($tgroup->id())),
+            'viewer'       => $Viewer,
         ]);
         unset($tgroup);
     } /* group */

--- a/templates/release/detail-releasegroup.twig
+++ b/templates/release/detail-releasegroup.twig
@@ -1,0 +1,9 @@
+{% for link in link_list %}
+<tr class="releases_{{ section_id }} group_torrent{{ hide ? ' hidden' : '' }}">
+    <td colspan="{{ viewer.ordinal.value('file-count-display') ? 7 + colspan_add : 6 + colspan_add }}" class="td_info">
+        <a href="{{ link.url }}">{{ link.platform }}</a>
+        {% if link.format %}<span class="format"> ({{ link.format }})</span>{% endif %}
+        {% if link.bitrate %}<span class="bitrate"> ({{ link.bitrate }})</span>{% endif %}
+    </td>
+</tr>
+{% endfor %}


### PR DESCRIPTION
## Summary
- Display streaming platform links on artist pages.
- Iterate release links instead of torrents.
- Add new Twig template for release group details.

## Testing
- `php -l sections/artist/artist.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: ext-gmp missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae066299dc83338926cc60605d083f