### PR TITLE
Rename tgroup usage to release usage

### DIFF
--- a/app/Artist.php
+++ b/app/Artist.php
@@ -499,12 +499,12 @@ class Artist extends BaseObject implements CollageEntry {
         return self::$db->collect(0, false);
     }
 
-    public function tgroupIdUsage(): array {
+    public function releaseIdUsage(): array {
         self::$db->prepared_query("
-            SELECT DISTINCT tg.ID
-            FROM torrents_group AS tg
-            INNER JOIN torrents_artists AS ta ON (ta.GroupID = tg.ID)
-            INNER JOIN artists_alias       aa ON (ta.AliasID = aa.AliasID)
+            SELECT DISTINCT r.ID
+            FROM release AS r
+            INNER JOIN release_artist AS ra ON (ra.GroupID = r.ID)
+            INNER JOIN artists_alias      aa ON (ra.AliasID = aa.AliasID)
             WHERE aa.ArtistID = ?
             ", $this->id
         );
@@ -512,7 +512,7 @@ class Artist extends BaseObject implements CollageEntry {
     }
 
     public function usageTotal(): int {
-        return count($this->requestIdUsage()) + count($this->tgroupIdUsage());
+        return count($this->requestIdUsage()) + count($this->releaseIdUsage());
     }
 
     /**

--- a/sections/artist/delete.php
+++ b/sections/artist/delete.php
@@ -13,7 +13,7 @@ if (is_null($artist)) {
 }
 
 $tgMan = new Gazelle\Manager\TGroup();
-$tgroupList = array_map(fn ($id) => $tgMan->findById($id), $artist->tgroupIdUsage());
+$tgroupList = array_map(fn ($id) => $tgMan->findById($id), $artist->releaseIdUsage());
 
 $reqMan = new Gazelle\Manager\Request();
 $requestList = array_map(fn ($id) => $reqMan->findById($id), $artist->requestIdUsage());

--- a/tests/phpunit/ArtistUsageTest.php
+++ b/tests/phpunit/ArtistUsageTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace GazelleUnitTest;
+
+use PHPUnit\Framework\TestCase;
+
+class ArtistUsageTest extends TestCase {
+    public function testUsageTotalUsesReleaseIds(): void {
+        $artist = new class extends \Gazelle\Artist {
+            public function __construct() {}
+            public function requestIdUsage(): array { return [1, 2]; }
+            public function releaseIdUsage(): array { return [3, 4]; }
+            public function tgroupIdUsage(): array { return [5, 6, 7]; }
+        };
+        $this->assertSame(4, $artist->usageTotal());
+    }
+}


### PR DESCRIPTION
## Summary
- rename `tgroupIdUsage` to `releaseIdUsage` and query `release` tables
- adjust artist delete handler for `releaseIdUsage`
- test `usageTotal()` counts release and request references

## Testing
- ⚠️ `composer install` *(missing ext-gmp extension)*
- ⚠️ `composer install --ignore-platform-req=ext-gmp` *(GitHub authentication required)*
- ⚠️ `./vendor/bin/phpunit --configuration misc/phpunit.xml` *(vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae09caaa5883338f5b672f23722ee0