### PR TITLE
Allow environment-based DB config and document seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,12 +147,15 @@ export MYSQL_HOST=127.0.0.1
 export MYSQL_PORT=36000
 export MYSQL_USER=gazelle
 export MYSQL_PASSWORD=password
+# optional: override migration credentials
+# export MYSQL_PHINX_USER=gazelle
+# export MYSQL_PHINX_PASS=password
 php vendor/bin/phinx seed:run -s ArtistReleaseSeeder
 ```
 
-If the web container fails to start with a database connection error, remove
-any existing `lib/override.config.php` so it can be regenerated with the
-current `MYSQL_*` environment settings.
+The `MYSQL_*` variables override any MySQL settings in
+`lib/override.config.php`. If you still see connection errors, delete the file
+so it can be regenerated with the current values.
 
 
 To access the database, look at `misc/docker/mysql-home/.my.cnf`

--- a/README.md
+++ b/README.md
@@ -133,6 +133,23 @@ pg-phinx migrate
 pg-phinx rollback
 ```
 
+To populate the MySQL database with sample data, run the appropriate seeders.
+When working inside the web container:
+
+`docker compose exec -T web php vendor/bin/phinx seed:run -s ArtistReleaseSeeder`
+
+If you prefer to run the seeder from the host, ensure the MySQL container is
+up (`docker compose up -d mysql`) and provide the connection information via
+environment variables:
+
+```
+export MYSQL_HOST=127.0.0.1
+export MYSQL_PORT=36000
+export MYSQL_USER=gazelle
+export MYSQL_PASSWORD=password
+php vendor/bin/phinx seed:run -s ArtistReleaseSeeder
+```
+
 
 To access the database, look at `misc/docker/mysql-home/.my.cnf`
 The credentials should match those used in the `docker-compose.yml` file.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ export MYSQL_PASSWORD=password
 php vendor/bin/phinx seed:run -s ArtistReleaseSeeder
 ```
 
+If the web container fails to start with a database connection error, remove
+any existing `lib/override.config.php` so it can be regenerated with the
+current `MYSQL_*` environment settings.
+
 
 To access the database, look at `misc/docker/mysql-home/.my.cnf`
 The credentials should match those used in the `docker-compose.yml` file.

--- a/lib/config.php
+++ b/lib/config.php
@@ -157,34 +157,66 @@ defined('USER_EDIT_SALT') or define('USER_EDIT_SALT', 'changeme');
 // environment. It is assumed that all will be changed in production.
 
 // Hostname of the mysql instance.
-defined('SQLHOST') or define('SQLHOST', getenv('MYSQL_HOST') ?: 'mysql');
+if (false !== getenv('MYSQL_HOST')) {
+    define('SQLHOST', getenv('MYSQL_HOST'));
+} elseif (!defined('SQLHOST')) {
+    define('SQLHOST', 'mysql');
+}
 
 // The TCP port to use.
-defined('SQLPORT') or define('SQLPORT', getenv('MYSQL_PORT') ?: 3306);
+if (false !== getenv('MYSQL_PORT')) {
+    define('SQLPORT', (int)getenv('MYSQL_PORT'));
+} elseif (!defined('SQLPORT')) {
+    define('SQLPORT', 3306);
+}
 
 // The socket to use. See the php documentation on mysqli::connect
 // to understand how these fit together. If the database and PHP interpreter
 // are running on the same host then you want to use a socket.
-defined('SQLSOCK') or define('SQLSOCK', getenv('MYSQL_SOCKET') ?: null);
+if (false !== getenv('MYSQL_SOCKET')) {
+    define('SQLSOCK', getenv('MYSQL_SOCKET'));
+} elseif (!defined('SQLSOCK')) {
+    define('SQLSOCK', null);
+}
 
 // The name of the database schema.
-defined('SQLDB') or define('SQLDB', getenv('MYSQL_DATABASE') ?: 'gazelle');
+if (false !== getenv('MYSQL_DATABASE')) {
+    define('SQLDB', getenv('MYSQL_DATABASE'));
+} elseif (!defined('SQLDB')) {
+    define('SQLDB', 'gazelle');
+}
 
 // The username of the website account. See the docs/01-MysqlRoles.txt
 // document for details on what roles need to be configured.
-defined('SQLLOGIN') or define('SQLLOGIN', getenv('MYSQL_USER') ?: 'gazelle');
+if (false !== getenv('MYSQL_USER')) {
+    define('SQLLOGIN', getenv('MYSQL_USER'));
+} elseif (!defined('SQLLOGIN')) {
+    define('SQLLOGIN', 'gazelle');
+}
 
 // The password of the above account.
-defined('SQLPASS') or define('SQLPASS', getenv('MYSQL_PASSWORD') ?: 'password');
+if (false !== getenv('MYSQL_PASSWORD')) {
+    define('SQLPASS', getenv('MYSQL_PASSWORD'));
+} elseif (!defined('SQLPASS')) {
+    define('SQLPASS', 'password');
+}
 
 // The username of the Phinx account (used for schema modifications).
 // In production, this account will have a different set of grants compared
 // to the website account (so that if the website account is compromised, it
 // cannot be used to drop tables or any other malicious activities).
-defined('SQL_PHINX_USER') or define('SQL_PHINX_USER', SQLLOGIN);
+if (false !== getenv('MYSQL_PHINX_USER')) {
+    define('SQL_PHINX_USER', getenv('MYSQL_PHINX_USER'));
+} elseif (!defined('SQL_PHINX_USER')) {
+    define('SQL_PHINX_USER', SQLLOGIN);
+}
 
 // Password of the above.
-defined('SQL_PHINX_PASS') or define('SQL_PHINX_PASS', SQLPASS);
+if (false !== getenv('MYSQL_PHINX_PASS')) {
+    define('SQL_PHINX_PASS', getenv('MYSQL_PHINX_PASS'));
+} elseif (!defined('SQL_PHINX_PASS')) {
+    define('SQL_PHINX_PASS', SQLPASS);
+}
 
 // ------------------------------------------------------------------------
 // Postgresql settings

--- a/lib/config.php
+++ b/lib/config.php
@@ -157,25 +157,25 @@ defined('USER_EDIT_SALT') or define('USER_EDIT_SALT', 'changeme');
 // environment. It is assumed that all will be changed in production.
 
 // Hostname of the mysql instance.
-defined('SQLHOST') or define('SQLHOST', 'mysql');
+defined('SQLHOST') or define('SQLHOST', getenv('MYSQL_HOST') ?: 'mysql');
 
 // The TCP port to use.
-defined('SQLPORT') or define('SQLPORT', 3306);
+defined('SQLPORT') or define('SQLPORT', getenv('MYSQL_PORT') ?: 3306);
 
 // The socket to use. See the php documentation on mysqli::connect
 // to understand how these fit together. If the database and PHP interpreter
 // are running on the same host then you want to use a socket.
-defined('SQLSOCK') or define('SQLSOCK', null);
+defined('SQLSOCK') or define('SQLSOCK', getenv('MYSQL_SOCKET') ?: null);
 
 // The name of the database schema.
-defined('SQLDB') or define('SQLDB', 'gazelle');
+defined('SQLDB') or define('SQLDB', getenv('MYSQL_DATABASE') ?: 'gazelle');
 
 // The username of the website account. See the docs/01-MysqlRoles.txt
 // document for details on what roles need to be configured.
-defined('SQLLOGIN') or define('SQLLOGIN', 'gazelle');
+defined('SQLLOGIN') or define('SQLLOGIN', getenv('MYSQL_USER') ?: 'gazelle');
 
 // The password of the above account.
-defined('SQLPASS') or define('SQLPASS', 'password');
+defined('SQLPASS') or define('SQLPASS', getenv('MYSQL_PASSWORD') ?: 'password');
 
 // The username of the Phinx account (used for schema modifications).
 // In production, this account will have a different set of grants compared

--- a/misc/docker/web/php-cli.ini
+++ b/misc/docker/web/php-cli.ini
@@ -1,1 +1,4 @@
 memory_limit = 160M
+
+; ensure MySQL PDO driver is available when using this minimal CLI config
+extension=pdo_mysql

--- a/misc/docker/web/php.ini
+++ b/misc/docker/web/php.ini
@@ -892,6 +892,7 @@ default_socket_timeout = 60
 ;extension=php_openssl.dll
 ;extension=php_pdo_firebird.dll
 ;extension=php_pdo_mysql.dll
+extension=pdo_mysql
 ;extension=php_pdo_oci.dll
 ;extension=php_pdo_odbc.dll
 ;extension=php_pdo_pgsql.dll

--- a/misc/example.local.config.php
+++ b/misc/example.local.config.php
@@ -24,8 +24,8 @@ define('RSS_HASH',     "");
 define('SEEDBOX_SALT', "");
 define('AVATAR_SALT',  "");
 
-define('SQL_PHINX_USER', 'root');
-define('SQL_PHINX_PASS', 'sc5tlc9JSCC6');
-
 // Docker setup runs the scheduler only once every 15 minutes
 define('SCHEDULER_DELAY', 1200);
+
+// Migrations use the same credentials as the application by default.
+// To override, define SQL_PHINX_USER and SQL_PHINX_PASS here.


### PR DESCRIPTION
## Summary
- make MySQL connection settings configurable via `MYSQL_*` env vars
- add README instructions for seeding demo data with phinx

## Testing
- `php -l lib/config.php`
- `composer install` *(fails: ext-gmp missing)*
- `vendor/bin/phpunit -c misc/phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aed32717d083338e3f3722a038f9aa