### PR TITLE
Fix blank artist page when artist has no releases

### DIFF
--- a/app/Artist.php
+++ b/app/Artist.php
@@ -144,15 +144,22 @@ class Artist extends BaseObject implements CollageEntry {
             ",
             $this->id
         );
+
+        // Always reset these members in case loadArtistRole() is invoked on a
+        // previously populated object or when the artist has no associated
+        // releases. Without this, consumers of sections() and groupIds() can
+        // receive undefined/null values which results in a blank page.
+        $this->section   = [];
+        $this->groupRole = [];
         $this->artistRole = [
-            ARTIST_MAIN => 0,
-            ARTIST_GUEST => 0,
-            ARTIST_REMIXER => 0,
-            ARTIST_COMPOSER => 0,
+            ARTIST_MAIN      => 0,
+            ARTIST_GUEST     => 0,
+            ARTIST_REMIXER   => 0,
+            ARTIST_COMPOSER  => 0,
             ARTIST_CONDUCTOR => 0,
-            ARTIST_DJ => 0,
-            ARTIST_PRODUCER => 0,
-            ARTIST_ARRANGER => 0,
+            ARTIST_DJ        => 0,
+            ARTIST_PRODUCER  => 0,
+            ARTIST_ARRANGER  => 0,
         ];
 
         while ([$groupId, $role, $releaseTypeId] = self::$db->next_record(MYSQLI_NUM, false)) {


### PR DESCRIPTION
## Summary
- Reset artist group and section arrays when loading artist roles to handle artists without releases

## Testing
- `php -l app/Artist.php`
- `composer install` *(fails: ext-gmp missing)*
- `vendor/bin/phpunit -c misc/phpunit.xml` *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af1b8290448333a5382f73fa3f36b4